### PR TITLE
[feat/#5]:  refresh reoate 구현

### DIFF
--- a/src/main/java/com/security/JWT_Hands_On/config/SecurityConfig.java
+++ b/src/main/java/com/security/JWT_Hands_On/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package com.security.JWT_Hands_On.config;
 
-import com.security.JWT_Hands_On.jwt.JWTFilter;
-import com.security.JWT_Hands_On.jwt.JWTUtil;
-import com.security.JWT_Hands_On.jwt.LoginFilter;
+import com.security.JWT_Hands_On.jwt.filter.JWTFilter;
+import com.security.JWT_Hands_On.jwt.service.JwtUtil;
+import com.security.JWT_Hands_On.jwt.filter.LoginFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -28,7 +28,7 @@ import java.util.Collections;
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
-    private final JWTUtil jwtUtil;
+    private final JwtUtil jwtUtil;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration  configuration) throws Exception {
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/" , "/join").permitAll()
+                        .requestMatchers("/login", "/" , "/join", "/reissue").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/security/JWT_Hands_On/jwt/controller/ReissuController.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/controller/ReissuController.java
@@ -1,0 +1,32 @@
+package com.security.JWT_Hands_On.jwt.controller;
+
+import com.security.JWT_Hands_On.jwt.service.JwtReissueService;
+import com.security.JWT_Hands_On.jwt.service.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+
+@RestController
+public class ReissuController {
+
+    private final JwtUtil jwtUtil;
+    private final JwtReissueService jwtReissueService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@CookieValue(name = "refresh") String refreshToken,
+                                     HttpServletRequest request,
+                                     HttpServletResponse response) {
+        System.out.println("refreshToken: " + refreshToken);
+
+        String newAccess = jwtReissueService.reissueToken(refreshToken);
+        response.setHeader("access", newAccess);
+        return new ResponseEntity<>(HttpStatus.OK);
+
+
+    }
+}

--- a/src/main/java/com/security/JWT_Hands_On/jwt/controller/ReissuController.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/controller/ReissuController.java
@@ -1,7 +1,9 @@
 package com.security.JWT_Hands_On.jwt.controller;
 
+import com.security.JWT_Hands_On.jwt.dto.ReissueTokenResponse;
 import com.security.JWT_Hands_On.jwt.service.JwtReissueService;
 import com.security.JWT_Hands_On.jwt.service.JwtUtil;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,14 +21,50 @@ public class ReissuController {
 
     @PostMapping("/reissue")
     public ResponseEntity<?> reissue(@CookieValue(name = "refresh") String refreshToken,
-                                     HttpServletRequest request,
-                                     HttpServletResponse response) {
+                                     HttpServletResponse response)
+    {
         System.out.println("refreshToken: " + refreshToken);
 
-        String newAccess = jwtReissueService.reissueToken(refreshToken);
-        response.setHeader("access", newAccess);
+        ReissueTokenResponse reissueToken = jwtReissueService.reissueToken(refreshToken);
+
+
+        String newAccessToken = reissueToken.getAccessToken();
+        String newRefreshToken = reissueToken.getRefreshToken();
+
+        //response
+        //이후 커스텀 예외 처리와 ExceptionHandler로 인한 모듈화 구현
+        response.setHeader("access", newAccessToken);
+        response.addCookie(createCookie("refresh", newRefreshToken));
+
         return new ResponseEntity<>(HttpStatus.OK);
-
-
     }
+
+    /*
+     * 임시 사용을 위한 쿠키 생성 메서드
+     * 서비스에 적용시 MemberSignUpService에서 다음 두 메서드를 모듈화
+    public static HttpHeaders setCookieAndHeader(LoginResponseDto loginResult) {
+    HttpHeaders headers = new HttpHeaders();
+    CookieUtil.setRefreshCookie(headers, loginResult.getRefreshToken());
+    HttpHeaderUtil.setAccessToken(headers, loginResult.getAccessToken());
+    return headers;
+  }
+
+  public static HttpHeaders setCookieAndHeader(ReIssueTokenDto reIssueTokenDto) {
+    HttpHeaders headers = new HttpHeaders();
+    HttpHeaderUtil.setAccessToken(headers, reIssueTokenDto.getAccessToken());
+    CookieUtil.setRefreshCookie(headers, reIssueTokenDto.getRefreshToken());
+    return headers;
+  }
+
+     * ****
+
+     */
+    private Cookie createCookie(String key, String value) {
+        Cookie cookie = new Cookie(key, value);
+        //cookie.setSecure("true");
+        //cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        return cookie;
+    }
+
 }

--- a/src/main/java/com/security/JWT_Hands_On/jwt/dto/ReissueTokenResponse.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/dto/ReissueTokenResponse.java
@@ -1,0 +1,12 @@
+package com.security.JWT_Hands_On.jwt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ReissueTokenResponse {
+
+    private final String refreshToken;
+    private final String accessToken;
+}

--- a/src/main/java/com/security/JWT_Hands_On/jwt/filter/JWTFilter.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/filter/JWTFilter.java
@@ -1,29 +1,27 @@
-package com.security.JWT_Hands_On.jwt;
+package com.security.JWT_Hands_On.jwt.filter;
 
 
-import com.security.JWT_Hands_On.dto.CustomUserDetails;
-import com.security.JWT_Hands_On.entity.MemberJwt;
+import com.security.JWT_Hands_On.member.dto.CustomUserDetails;
+import com.security.JWT_Hands_On.member.entity.MemberJwt;
+import com.security.JWT_Hands_On.jwt.service.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.reflect.Member;
 
 @RequiredArgsConstructor
 
 public class JWTFilter extends OncePerRequestFilter {
-    private final JWTUtil jwtUtil;
+    private final JwtUtil jwtUtil;
 
     /**********************
     * Filter에 대한 내부 구현

--- a/src/main/java/com/security/JWT_Hands_On/jwt/filter/LoginFilter.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/filter/LoginFilter.java
@@ -1,6 +1,7 @@
-package com.security.JWT_Hands_On.jwt;
+package com.security.JWT_Hands_On.jwt.filter;
 
-import com.security.JWT_Hands_On.dto.CustomUserDetails;
+import com.security.JWT_Hands_On.member.dto.CustomUserDetails;
+import com.security.JWT_Hands_On.jwt.service.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
@@ -24,7 +25,7 @@ import java.util.Iterator;
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
-    private final JWTUtil jwtUtil;
+    private final JwtUtil jwtUtil;
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {

--- a/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtReissueService.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtReissueService.java
@@ -1,6 +1,7 @@
 package com.security.JWT_Hands_On.jwt.service;
 
 
+import com.security.JWT_Hands_On.jwt.dto.ReissueTokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +12,7 @@ public class JwtReissueService {
 
     private final JwtUtil jwtUtil;
 
-    public String reissueToken(String refreshToken) {
+    public ReissueTokenResponse reissueToken(String refreshToken) {
 
 
         System.out.println("session: " + jwtUtil.getUsername(refreshToken));
@@ -34,8 +35,11 @@ public class JwtReissueService {
         String role = jwtUtil.getRole(refreshToken);
 
         //새로운 jwt token 만들기
+        //refresh rotate를 사용하도록 반환
         System.out.println("reissued token created");
-        return jwtUtil.createJwt("access", username, role, 600000L);
+        String newAccessToken = jwtUtil.createJwt("access", username, role, 600000L);
+        String newRefreshToken = jwtUtil.createJwt("refresh", username, role, 86400000L);
 
+        return new ReissueTokenResponse(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtReissueService.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtReissueService.java
@@ -1,0 +1,41 @@
+package com.security.JWT_Hands_On.jwt.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+
+@Service
+public class JwtReissueService {
+
+    private final JwtUtil jwtUtil;
+
+    public String reissueToken(String refreshToken) {
+
+
+        System.out.println("session: " + jwtUtil.getUsername(refreshToken));
+        System.out.println("category: " + jwtUtil.getCategory(refreshToken));
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new IllegalArgumentException("Refresh token null");
+        }
+        if (jwtUtil.isExpired(refreshToken)) {
+            throw new IllegalArgumentException("Refresh token expired");
+        }
+
+        String category = jwtUtil.getCategory(refreshToken);
+        if(!category.equals("refresh")) {
+            throw new IllegalArgumentException("Token category is not refresh");
+        }
+
+        //refresh token으로부터 username, role 가져오기
+        String username = jwtUtil.getUsername(refreshToken);
+        String role = jwtUtil.getRole(refreshToken);
+
+        //새로운 jwt token 만들기
+        System.out.println("reissued token created");
+        return jwtUtil.createJwt("access", username, role, 600000L);
+
+    }
+}

--- a/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtUtil.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.security.JWT_Hands_On.jwt;
+package com.security.JWT_Hands_On.jwt.service;
 
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,11 +19,11 @@ import java.util.Date;
  */
 
 @Component
-public class JWTUtil {
+public class JwtUtil {
 
     private SecretKey secretKey;
 
-    public JWTUtil(@Value("${jwt.secret}")String secret) {
+    public JwtUtil(@Value("${jwt.secret}")String secret) {
         this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
     //token과 secretKey를 비교하여 유저 정보를 가져오는 메서드

--- a/src/main/java/com/security/JWT_Hands_On/member/controller/AdminController.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/controller/AdminController.java
@@ -1,4 +1,4 @@
-package com.security.JWT_Hands_On.controller;
+package com.security.JWT_Hands_On.member.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/security/JWT_Hands_On/member/controller/JoinController.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/controller/JoinController.java
@@ -1,8 +1,8 @@
-package com.security.JWT_Hands_On.controller;
+package com.security.JWT_Hands_On.member.controller;
 
 
-import com.security.JWT_Hands_On.dto.JoinRequsetDto;
-import com.security.JWT_Hands_On.service.JoinService;
+import com.security.JWT_Hands_On.member.dto.JoinRequsetDto;
+import com.security.JWT_Hands_On.member.service.JoinService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/security/JWT_Hands_On/member/controller/MainController.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/controller/MainController.java
@@ -1,7 +1,6 @@
-package com.security.JWT_Hands_On.controller;
+package com.security.JWT_Hands_On.member.controller;
 
 
-import lombok.Getter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/com/security/JWT_Hands_On/member/dto/CustomUserDetails.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/dto/CustomUserDetails.java
@@ -1,6 +1,6 @@
-package com.security.JWT_Hands_On.dto;
+package com.security.JWT_Hands_On.member.dto;
 
-import com.security.JWT_Hands_On.entity.MemberJwt;
+import com.security.JWT_Hands_On.member.entity.MemberJwt;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 

--- a/src/main/java/com/security/JWT_Hands_On/member/dto/JoinRequsetDto.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/dto/JoinRequsetDto.java
@@ -1,4 +1,4 @@
-package com.security.JWT_Hands_On.dto;
+package com.security.JWT_Hands_On.member.dto;
 
 
 import lombok.Getter;

--- a/src/main/java/com/security/JWT_Hands_On/member/entity/MemberJwt.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/entity/MemberJwt.java
@@ -1,4 +1,4 @@
-package com.security.JWT_Hands_On.entity;
+package com.security.JWT_Hands_On.member.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/security/JWT_Hands_On/member/repository/MemberRepository.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
-package com.security.JWT_Hands_On.repository;
+package com.security.JWT_Hands_On.member.repository;
 
-import com.security.JWT_Hands_On.entity.MemberJwt;
+import com.security.JWT_Hands_On.member.entity.MemberJwt;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<MemberJwt, Long> {

--- a/src/main/java/com/security/JWT_Hands_On/member/service/CustomUserDetailsService.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/service/CustomUserDetailsService.java
@@ -1,8 +1,8 @@
-package com.security.JWT_Hands_On.service;
+package com.security.JWT_Hands_On.member.service;
 
-import com.security.JWT_Hands_On.dto.CustomUserDetails;
-import com.security.JWT_Hands_On.entity.MemberJwt;
-import com.security.JWT_Hands_On.repository.MemberRepository;
+import com.security.JWT_Hands_On.member.dto.CustomUserDetails;
+import com.security.JWT_Hands_On.member.entity.MemberJwt;
+import com.security.JWT_Hands_On.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/security/JWT_Hands_On/member/service/JoinService.java
+++ b/src/main/java/com/security/JWT_Hands_On/member/service/JoinService.java
@@ -1,8 +1,8 @@
-package com.security.JWT_Hands_On.service;
+package com.security.JWT_Hands_On.member.service;
 
-import com.security.JWT_Hands_On.dto.JoinRequsetDto;
-import com.security.JWT_Hands_On.entity.MemberJwt;
-import com.security.JWT_Hands_On.repository.MemberRepository;
+import com.security.JWT_Hands_On.member.dto.JoinRequsetDto;
+import com.security.JWT_Hands_On.member.entity.MemberJwt;
+import com.security.JWT_Hands_On.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-jwt-honds-on-Spring-boot-3/issues/5
  
  


# 🔑 Key Changes
- access 토큰 재발급시 refresh 토큰도 재발급
- header에 access token, cookie에 refresh 토큰을 담아서 response를 통해 응답 설정
- 토큰 재발급에 관한 Reissue 컨트롤러, 서비스 구현



# 📢 After To-do
- [ ] 서버측 주도권 강화
- [ ] DB에 토큰 저장하기
- [ ] 로그아웃 시 서버에서 토큰이 완전히 삭제

