### PR TITLE
[feat/#5]: 서버측 주도권 강화

### DIFF
--- a/src/main/java/com/security/JWT_Hands_On/config/SecurityConfig.java
+++ b/src/main/java/com/security/JWT_Hands_On/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.security.JWT_Hands_On.config;
 
+import com.security.JWT_Hands_On.jwt.filter.CustomLogoutFilter;
 import com.security.JWT_Hands_On.jwt.filter.JWTFilter;
 import com.security.JWT_Hands_On.jwt.repository.RefreshRepository;
 import com.security.JWT_Hands_On.jwt.service.JwtUtil;
@@ -17,6 +18,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -80,7 +82,9 @@ public class SecurityConfig {
                 로그인 필터 추가
                 필터가 중복 호출될 수 있으므로 Bean을 이용한 종속성 주입 대신 객체 생성 후 의존성 주입
                  */
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshRepository), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshRepository), UsernamePasswordAuthenticationFilter.class)
+                //로그아웃 필터 등록
+                .addFilterAt(new CustomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/security/JWT_Hands_On/config/SecurityConfig.java
+++ b/src/main/java/com/security/JWT_Hands_On/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.security.JWT_Hands_On.config;
 
 import com.security.JWT_Hands_On.jwt.filter.JWTFilter;
+import com.security.JWT_Hands_On.jwt.repository.RefreshRepository;
 import com.security.JWT_Hands_On.jwt.service.JwtUtil;
 import com.security.JWT_Hands_On.jwt.filter.LoginFilter;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,6 +30,7 @@ public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
+    private final RefreshRepository refreshRepository;;
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration  configuration) throws Exception {
@@ -78,7 +80,7 @@ public class SecurityConfig {
                 로그인 필터 추가
                 필터가 중복 호출될 수 있으므로 Bean을 이용한 종속성 주입 대신 객체 생성 후 의존성 주입
                  */
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshRepository), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/security/JWT_Hands_On/jwt/controller/ReissuController.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/controller/ReissuController.java
@@ -1,6 +1,7 @@
 package com.security.JWT_Hands_On.jwt.controller;
 
 import com.security.JWT_Hands_On.jwt.dto.ReissueTokenResponse;
+import com.security.JWT_Hands_On.jwt.repository.RefreshRepository;
 import com.security.JWT_Hands_On.jwt.service.JwtReissueService;
 import com.security.JWT_Hands_On.jwt.service.JwtUtil;
 import jakarta.servlet.http.Cookie;

--- a/src/main/java/com/security/JWT_Hands_On/jwt/entity/RefreshEntity.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/entity/RefreshEntity.java
@@ -1,0 +1,28 @@
+package com.security.JWT_Hands_On.jwt.entity;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+//JWT 세션 저장소
+
+@Getter
+@Setter
+
+@Entity
+public class RefreshEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String refresh;
+
+    private String expiration;
+
+}

--- a/src/main/java/com/security/JWT_Hands_On/jwt/filter/CustomLogoutFilter.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/filter/CustomLogoutFilter.java
@@ -1,0 +1,120 @@
+package com.security.JWT_Hands_On.jwt.filter;
+
+import com.security.JWT_Hands_On.jwt.repository.RefreshRepository;
+import com.security.JWT_Hands_On.jwt.service.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    /******************************************************
+     * 커스텀 필터 구현
+     * 모든 요청은 커스텀 필터를 거쳐 서버로 들어옴
+     * [요청 검증 후 다음 필터로 넘김]
+     * 요청이 로그아웃인지 확인
+     * HTTP 메서드 확인
+     *
+     * [쿠키에서 Refresh Token 가져오고 검증]
+     * 쿠키가 없을 경우 예외 처리
+     * Refresh Token이 만료되었다면 예외 처리
+     * 토큰이 활성화되어있는 경우 refresh token인지 확인 후 예외 처리
+     * DB에서 해당 토큰이 저장되었는지 확인 후 예외 처리
+     *
+     * [로그아웃 진행]
+     * Refresh DB에서 제거
+     * Cookie 초기화(시간, 경로, secure 설정 제거)
+     * 응답 설정
+
+     ****************************************************************/
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        //요청이 로그아웃인지 확인
+        String requestUri = request.getRequestURI();
+        System.out.println("요청 uri: " + requestUri);
+        if (!requestUri.matches("^/logout$")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //HTTP 메서드 확인
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //refresh token 검증
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+        System.out.println("검증 후 refresh: " + refresh);
+
+        if (refresh == null) {
+            System.out.println("refresh is null");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // 토큰 만료 검증
+        if (jwtUtil.isExpired(refresh)) {
+            System.out.println("refresh 토큰이 이미 만료됨");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //토큰 카테고리 검증
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+            System.out.println("토큰 카테고리가 refresh가 아님");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // DB에 저장된 토큰인지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+            System.out.println("세션 저장소에 해당 refresh 토큰 없음");
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        // 로그아웃 진행
+
+        //Refresh 토큰 DB에서 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        //Refresh 쿠키 값 초기화
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        System.out.println("로그 아웃 성공");
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+
+
+}

--- a/src/main/java/com/security/JWT_Hands_On/jwt/repository/RefreshRepository.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/repository/RefreshRepository.java
@@ -1,0 +1,13 @@
+package com.security.JWT_Hands_On.jwt.repository;
+
+import com.security.JWT_Hands_On.jwt.entity.RefreshEntity;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
+
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+}

--- a/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtReissueService.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtReissueService.java
@@ -2,8 +2,12 @@ package com.security.JWT_Hands_On.jwt.service;
 
 
 import com.security.JWT_Hands_On.jwt.dto.ReissueTokenResponse;
+import com.security.JWT_Hands_On.jwt.entity.RefreshEntity;
+import com.security.JWT_Hands_On.jwt.repository.RefreshRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Date;
 
 @RequiredArgsConstructor
 
@@ -11,6 +15,7 @@ import org.springframework.stereotype.Service;
 public class JwtReissueService {
 
     private final JwtUtil jwtUtil;
+    private  final RefreshRepository refreshRepository;
 
     public ReissueTokenResponse reissueToken(String refreshToken) {
 
@@ -30,6 +35,12 @@ public class JwtReissueService {
             throw new IllegalArgumentException("Token category is not refresh");
         }
 
+        //DB에 refresh token이 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refreshToken);
+        if(!isExist) {
+            throw new IllegalArgumentException("Refresh token does not exist, Invalid access token");
+        }
+
         //refresh token으로부터 username, role 가져오기
         String username = jwtUtil.getUsername(refreshToken);
         String role = jwtUtil.getRole(refreshToken);
@@ -40,6 +51,22 @@ public class JwtReissueService {
         String newAccessToken = jwtUtil.createJwt("access", username, role, 600000L);
         String newRefreshToken = jwtUtil.createJwt("refresh", username, role, 86400000L);
 
+        //기존의 refresh 토큰 삭제 후 새 refresh 토큰 저장
+        refreshRepository.deleteByRefresh(refreshToken);
+        addRefreshEntity(username, newRefreshToken, 86400000L);
+
         return new ReissueTokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    private void addRefreshEntity(String username, String refresh, Long expireMs) {
+        //세션 만료 일자 생성
+        Date date = new Date(System.currentTimeMillis() + expireMs);
+
+        RefreshEntity refreshEntity = new RefreshEntity();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
     }
 }

--- a/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtReissueService.java
+++ b/src/main/java/com/security/JWT_Hands_On/jwt/service/JwtReissueService.java
@@ -31,6 +31,7 @@ public class JwtReissueService {
         }
 
         String category = jwtUtil.getCategory(refreshToken);
+        System.out.println("category: " + category);
         if(!category.equals("refresh")) {
             throw new IllegalArgumentException("Token category is not refresh");
         }


### PR DESCRIPTION
 # ✒️ 관련 이슈번호
- https://github.com/kimgt0128/security-jwt-honds-on-Spring-boot-3/issues/5
  
  


# 🔑 Key Changes
- 서버측 refresh 토큰 저장소 구현 & 관리
  - 로그인 시 토큰 저장
  - 토큰 재발급시 DB에서 만료된 토큰 삭제
- SecurityConfig에 refresh 저장소 의존성 추가
- refresh 저장소를 통한 서버측 로그아웃 구현
  - 유저가 로그아웃한 이후에 토큰 탈취에 대한 위험성 제거


# 📢 After To-do
- [ ] 추가 보안 구상 서비스에 적용해보기

